### PR TITLE
Feature/remove liquidity

### DIFF
--- a/src/Pool.sol
+++ b/src/Pool.sol
@@ -167,7 +167,10 @@ contract Pool is IPool, Ownable {
         mapPairId_streamQueue_back[pairId]++;
     }
 
-    function enqueueRemoveLiquidityStream(address token, RemoveLiquidityStream memory removeLiquidityStream) external onlyPoolLogic {
+    function enqueueRemoveLiquidityStream(address token, RemoveLiquidityStream memory removeLiquidityStream)
+        external
+        onlyPoolLogic
+    {
         mapToken_removeLiqStreamQueue[token].push(removeLiquidityStream);
         mapToken_removeLiqQueue_back[token]++;
         // @note keep this in mind WHEN implementing cancelRemoveLiquidityStreamRequest()
@@ -270,13 +273,15 @@ contract Pool is IPool, Ownable {
     }
 
     function updateReservesAndRemoveLiqStream(bytes memory updatedReservesAndRemoveLiqData) external onlyPoolLogic {
-        (address token, uint256 reservesToRemove, uint conversionRemaining, uint streamCountRemaining) = abi.decode(updatedReservesAndRemoveLiqData, (address, uint256, uint256, uint256));
-        RemoveLiquidityStream storage removeLiqStream = mapToken_removeLiqStreamQueue[token][mapToken_removeLiqQueue_front[token]];
+        (address token, uint256 reservesToRemove, uint256 conversionRemaining, uint256 streamCountRemaining) =
+            abi.decode(updatedReservesAndRemoveLiqData, (address, uint256, uint256, uint256));
+        RemoveLiquidityStream storage removeLiqStream =
+            mapToken_removeLiqStreamQueue[token][mapToken_removeLiqQueue_front[token]];
         removeLiqStream.conversionRemaining = conversionRemaining;
         removeLiqStream.streamCountRemaining = streamCountRemaining;
         removeLiqStream.tokenAmountOut += reservesToRemove;
         mapToken_reserveA[token] -= reservesToRemove;
-        uint lpUnitsToRemove = removeLiqStream.conversionPerStream;
+        uint256 lpUnitsToRemove = removeLiqStream.conversionPerStream;
         mapToken_poolOwnershipUnitsTotal[token] -= lpUnitsToRemove;
         // @note not doing this here because lpUnits are subtracted when enqueuing user's removeLiq request
         // userLpUnitInfo[removeLiqStream.user][token] -= lpUnitsToRemove;
@@ -443,9 +448,7 @@ contract Pool is IPool, Ownable {
         returns (RemoveLiquidityStream[] memory removeLiquidityStream, uint256 front, uint256 back)
     {
         return (
-            mapToken_removeLiqStreamQueue[pool],
-            mapToken_removeLiqQueue_front[pool],
-            mapToken_removeLiqQueue_back[pool]
+            mapToken_removeLiqStreamQueue[pool], mapToken_removeLiqQueue_front[pool], mapToken_removeLiqQueue_back[pool]
         );
     }
 

--- a/src/Pool.sol
+++ b/src/Pool.sol
@@ -170,6 +170,9 @@ contract Pool is IPool, Ownable {
     function enqueueRemoveLiquidityStream(address token, RemoveLiquidityStream memory removeLiquidityStream) external onlyPoolLogic {
         mapToken_removeLiqStreamQueue[token].push(removeLiquidityStream);
         mapToken_removeLiqQueue_back[token]++;
+        // @note keep this in mind WHEN implementing cancelRemoveLiquidityStreamRequest()
+        // subtracting lp balance straight away to restrict users creating invalid removeLiq requests.
+        userLpUnitInfo[removeLiquidityStream.user][token] -= removeLiquidityStream.lpAmount;
     }
 
     // addLiqParams encoding format => (address token, address user, uint amount, uint256 newLpUnits, uint256 newDUnits, uint256 poolFeeCollected)
@@ -274,8 +277,9 @@ contract Pool is IPool, Ownable {
         removeLiqStream.tokenAmountOut += reservesToRemove;
         mapToken_reserveA[token] -= reservesToRemove;
         uint lpUnitsToRemove = removeLiqStream.conversionPerStream;
-        userLpUnitInfo[removeLiqStream.user][token] -= lpUnitsToRemove;
         mapToken_poolOwnershipUnitsTotal[token] -= lpUnitsToRemove;
+        // @note not doing this here because lpUnits are subtracted when enqueuing user's removeLiq request
+        // userLpUnitInfo[removeLiqStream.user][token] -= lpUnitsToRemove;
     }
 
     // @todo ask if we should sort it here, or pass sorted array from logic and just save

--- a/src/PoolLogic.sol
+++ b/src/PoolLogic.sol
@@ -317,15 +317,15 @@ contract PoolLogic is Ownable, IPoolLogic {
         uint256 streamCount = calculateStreamCount(lpUnits, pool.globalSlippage(), reserveD);
         uint256 lpUnitsPerStream = lpUnits / streamCount;
         RemoveLiquidityStream memory removeLiqStream = RemoveLiquidityStream({
-            user:user,
-            lpAmount:lpUnits,
-            streamCountTotal:streamCount,
-            streamCountRemaining:streamCount,
-            conversionPerStream:lpUnitsPerStream,
-            tokenAmountOut:0,
-            conversionRemaining:lpUnits
+            user: user,
+            lpAmount: lpUnits,
+            streamCountTotal: streamCount,
+            streamCountRemaining: streamCount,
+            conversionPerStream: lpUnitsPerStream,
+            tokenAmountOut: 0,
+            conversionRemaining: lpUnits
         });
-        IPoolActions(POOL_ADDRESS).enqueueRemoveLiquidityStream(token,removeLiqStream);
+        IPoolActions(POOL_ADDRESS).enqueueRemoveLiquidityStream(token, removeLiqStream);
         _executeRemoveLiquidity(token);
     }
 
@@ -334,7 +334,8 @@ contract PoolLogic is Ownable, IPoolLogic {
     }
 
     function _executeRemoveLiquidity(address token) internal {
-        (RemoveLiquidityStream[] memory removeLiqStreams, uint256 front, uint256 back) = pool.removeLiquidityStreamQueue(token);
+        (RemoveLiquidityStream[] memory removeLiqStreams, uint256 front, uint256 back) =
+            pool.removeLiquidityStreamQueue(token);
         if (front == back) {
             return;
         }
@@ -350,19 +351,20 @@ contract PoolLogic is Ownable, IPoolLogic {
 
         RemoveLiquidityStream memory frontStream = removeLiqStreams[front];
 
-        uint256 assetToTransfer = calculateAssetTransfer(frontStream.conversionPerStream, reserveA, poolOwnershipUnitsTotal);
+        uint256 assetToTransfer =
+            calculateAssetTransfer(frontStream.conversionPerStream, reserveA, poolOwnershipUnitsTotal);
         frontStream.conversionRemaining -= frontStream.conversionPerStream;
         frontStream.streamCountRemaining--;
         frontStream.tokenAmountOut += assetToTransfer;
 
-        bytes memory updatedRemoveLiqData = abi.encode(token ,assetToTransfer ,frontStream.conversionRemaining, frontStream.streamCountRemaining);
+        bytes memory updatedRemoveLiqData =
+            abi.encode(token, assetToTransfer, frontStream.conversionRemaining, frontStream.streamCountRemaining);
         IPoolActions(POOL_ADDRESS).updateReservesAndRemoveLiqStream(updatedRemoveLiqData);
 
-        if(frontStream.streamCountRemaining == 0) {
-            IPoolActions(POOL_ADDRESS).transferTokens(token,frontStream.user,frontStream.tokenAmountOut);
+        if (frontStream.streamCountRemaining == 0) {
+            IPoolActions(POOL_ADDRESS).transferTokens(token, frontStream.user, frontStream.tokenAmountOut);
             IPoolActions(POOL_ADDRESS).dequeueRemoveLiquidity_streamQueue(token);
         }
-
     }
 
     function swap(address user, address tokenIn, address tokenOut, uint256 amountIn, uint256 executionPrice)

--- a/src/PoolLogic.sol
+++ b/src/PoolLogic.sol
@@ -5,7 +5,7 @@ import {IPoolStates} from "./interfaces/pool/IPoolStates.sol";
 import {IPoolLogic} from "./interfaces/IPoolLogic.sol";
 import {IPoolActions} from "./interfaces/pool/IPoolActions.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {Swap, LiquidityStream, StreamDetails, TYPE_OF_LP} from "src/lib/SwapQueue.sol";
+import {Swap, LiquidityStream, StreamDetails, TYPE_OF_LP, RemoveLiquidityStream} from "src/lib/SwapQueue.sol";
 import {DSMath} from "src/lib/DSMath.sol";
 
 contract PoolLogic is Ownable, IPoolLogic {
@@ -314,10 +314,55 @@ contract PoolLogic is Ownable, IPoolLogic {
             uint256 poolFeeCollected,
             bool initialized
         ) = pool.poolInfo(address(token));
-        uint256 assetToTransfer = calculateAssetTransfer(lpUnits, reserveA, poolOwnershipUnitsTotal);
-        uint256 dAmountToDeduct = calculateDToDeduct(lpUnits, reserveD, poolOwnershipUnitsTotal);
-        bytes memory removeLiqParams = abi.encode(token, user, lpUnits, assetToTransfer, dAmountToDeduct, 0); // poolFeeCollected = 0 until logic is finalized
-        IPoolActions(POOL_ADDRESS).removeLiquidity(removeLiqParams);
+        uint256 streamCount = calculateStreamCount(lpUnits, pool.globalSlippage(), reserveD);
+        uint256 lpUnitsPerStream = lpUnits / streamCount;
+        RemoveLiquidityStream memory removeLiqStream = RemoveLiquidityStream({
+            user:user,
+            lpAmount:lpUnits,
+            streamCountTotal:streamCount,
+            streamCountRemaining:streamCount,
+            conversionPerStream:lpUnitsPerStream,
+            tokenAmountOut:0,
+            conversionRemaining:lpUnits
+        });
+        IPoolActions(POOL_ADDRESS).enqueueRemoveLiquidityStream(token,removeLiqStream);
+        _executeRemoveLiquidity(token);
+    }
+
+    function processRemoveLiquidity(address token) external onlyRouter {
+        _executeRemoveLiquidity(token);
+    }
+
+    function _executeRemoveLiquidity(address token) internal {
+        (RemoveLiquidityStream[] memory removeLiqStreams, uint256 front, uint256 back) = pool.removeLiquidityStreamQueue(token);
+        if (front == back) {
+            return;
+        }
+
+        (
+            uint256 reserveD,
+            uint256 poolOwnershipUnitsTotal,
+            uint256 reserveA,
+            uint256 initialDToMint,
+            uint256 poolFeeCollected,
+            bool initialized
+        ) = pool.poolInfo(address(token));
+
+        RemoveLiquidityStream memory frontStream = removeLiqStreams[front];
+
+        uint256 assetToTransfer = calculateAssetTransfer(frontStream.conversionPerStream, reserveA, poolOwnershipUnitsTotal);
+        frontStream.conversionRemaining -= frontStream.conversionPerStream;
+        frontStream.streamCountRemaining--;
+        frontStream.tokenAmountOut += assetToTransfer;
+
+        bytes memory updatedRemoveLiqData = abi.encode(token ,assetToTransfer ,frontStream.conversionRemaining, frontStream.streamCountRemaining);
+        IPoolActions(POOL_ADDRESS).updateReservesAndRemoveLiqStream(updatedRemoveLiqData);
+
+        if(frontStream.streamCountRemaining == 0) {
+            IPoolActions(POOL_ADDRESS).transferTokens(token,frontStream.user,frontStream.tokenAmountOut);
+            IPoolActions(POOL_ADDRESS).dequeueRemoveLiquidity_streamQueue(token);
+        }
+
     }
 
     function swap(address user, address tokenIn, address tokenOut, uint256 amountIn, uint256 executionPrice)

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import {IPoolActions} from "./interfaces/pool/IPoolActions.sol";
+import {IPoolLogicActions} from "./interfaces/pool-logic/IPoolLogicActions.sol";
 import {IPoolStates} from "./interfaces/pool/IPoolStates.sol";
 import {IPoolLogic} from "./interfaces/IPoolLogic.sol";
 import {IRouter} from "./interfaces/IRouter.sol";
@@ -123,7 +124,12 @@ contract Router is Ownable, ReentrancyGuard, IRouter {
     function removeLiquidity(address token, uint256 lpUnits) external override nonReentrant {
         if (!poolExist(token)) revert InvalidPool();
         if (lpUnits == 0 || lpUnits > poolStates.userLpUnitInfo(msg.sender, token)) revert InvalidAmount();
-
+        (uint256 reserveD,,,,,) = poolStates.poolInfo(address(token));
+        uint256 streamCount = IPoolLogicActions(poolStates.POOL_LOGIC()).calculateStreamCount(lpUnits, poolStates.globalSlippage() , reserveD);
+        if (lpUnits % streamCount != 0) {
+            uint256 swapPerStream = lpUnits / streamCount;
+            lpUnits = streamCount * swapPerStream;
+        }
         IPoolLogic(poolStates.POOL_LOGIC()).removeLiquidity(token, msg.sender, lpUnits);
 
         emit LiquidityRemoved(msg.sender, token, lpUnits);

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -125,7 +125,9 @@ contract Router is Ownable, ReentrancyGuard, IRouter {
         if (!poolExist(token)) revert InvalidPool();
         if (lpUnits == 0 || lpUnits > poolStates.userLpUnitInfo(msg.sender, token)) revert InvalidAmount();
         (uint256 reserveD,,,,,) = poolStates.poolInfo(address(token));
-        uint256 streamCount = IPoolLogicActions(poolStates.POOL_LOGIC()).calculateStreamCount(lpUnits, poolStates.globalSlippage() , reserveD);
+        uint256 streamCount = IPoolLogicActions(poolStates.POOL_LOGIC()).calculateStreamCount(
+            lpUnits, poolStates.globalSlippage(), reserveD
+        );
         if (lpUnits % streamCount != 0) {
             uint256 swapPerStream = lpUnits / streamCount;
             lpUnits = streamCount * swapPerStream;

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -129,6 +129,11 @@ contract Router is Ownable, ReentrancyGuard, IRouter {
         emit LiquidityRemoved(msg.sender, token, lpUnits);
     }
 
+    function processRemoveLiquidity(address token) external {
+        if (!poolExist(token)) revert InvalidPool();
+        IPoolLogic(poolStates.POOL_LOGIC()).processRemoveLiquidity(token);
+    }
+
     function swap(address tokenIn, address tokenOut, uint256 amountIn, uint256 executionPrice) external nonReentrant {
         if (amountIn == 0) revert InvalidAmount();
         if (executionPrice == 0) revert InvalidExecutionPrice();

--- a/src/interfaces/pool-logic/IPoolLogicActions.sol
+++ b/src/interfaces/pool-logic/IPoolLogicActions.sol
@@ -23,6 +23,7 @@ interface IPoolLogicActions {
     function addToPoolSingle(address token, address user, uint256 amount) external;
     function streamDToPool(address tokenA, address tokenB, address user, uint256 amountB) external;
     function processLiqStream(address tokenA, address tokenB) external;
+    function processRemoveLiquidity(address token) external;
     function addLiquidity(address token, address user, uint256 amount) external;
     function removeLiquidity(address token, address user, uint256 lpUnits) external;
     function swap(address user, address tokenIn, address tokenOut, uint256 amountIn, uint256 executionPrice) external;

--- a/src/interfaces/pool/IPoolActions.sol
+++ b/src/interfaces/pool/IPoolActions.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {Swap, LiquidityStream} from "../../lib/SwapQueue.sol";
+import {Swap, LiquidityStream, RemoveLiquidityStream} from "../../lib/SwapQueue.sol";
 
 interface IPoolActions {
     // creatPoolParams encoding format => (address token, address user, uint256 amount, uint256 minLaunchReserveA, uint256 minLaunchReserveD, uint256 initialDToMint, uint newLpUnits, uint newDUnits, uint256 poolFeeCollected)
@@ -15,12 +15,16 @@ interface IPoolActions {
     function addLiquidity(bytes memory addLiqParams) external;
     // removeLiqParams encoding format => (address token, address user, uint lpUnits, uint256 assetToTransfer, uint256 dAmountToDeduct, uint256 poolFeeCollected)
     function removeLiquidity(bytes memory removeLiqParams) external;
+    // updatedReservesAndRemoveLiqData encoding format => (address token, uint256 reservesToRemove, uint conversionRemaining, uint streamCountRemaining)
+    function updateReservesAndRemoveLiqStream(bytes memory updatedReservesAndRemoveLiqData) external;
     function enqueueSwap_pairStreamQueue(bytes32 pairId, Swap memory swap) external;
     function enqueueSwap_pairPendingQueue(bytes32 pairId, Swap memory swap) external;
     function enqueueLiquidityStream(bytes32 pairId, LiquidityStream memory liquidityStream) external;
+    function enqueueRemoveLiquidityStream(address token, RemoveLiquidityStream memory removeLiquidityStream) external;
     function dequeueSwap_pairStreamQueue(bytes32 pairId) external;
     function dequeueSwap_pairPendingQueue(bytes32 pairId) external;
     function dequeueLiquidityStream_streamQueue(bytes32 pairId) external;
+    function dequeueRemoveLiquidity_streamQueue(address token) external;
     // updateReservesParams encoding format => (bool aToB, address tokenA, address tokenB, uint256 reserveA_A, uint256 reserveD_A,uint256 reserveA_B, uint256 reserveD_B)
     function updateReserves(bytes memory updateReservesParams) external;
     // updateReservesParams encoding format => (address tokenA, address tokenB, uint256 reserveA_A, uint256 reserveA_B, uint256 changeInD)

--- a/src/interfaces/pool/IPoolStates.sol
+++ b/src/interfaces/pool/IPoolStates.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {Swap, LiquidityStream} from "../../lib/SwapQueue.sol";
+import {Swap, LiquidityStream, RemoveLiquidityStream} from "../../lib/SwapQueue.sol";
 
 interface IPoolStates {
     function poolInfo(address)
@@ -28,4 +28,9 @@ interface IPoolStates {
         external
         view
         returns (LiquidityStream[] memory liquidityStream, uint256 front, uint256 back);
+    function removeLiquidityStreamQueue(address)
+        external
+        view
+        returns (RemoveLiquidityStream[] memory removeLiquidityStream, uint256 front, uint256 back);
+
 }

--- a/src/lib/SwapQueue.sol
+++ b/src/lib/SwapQueue.sol
@@ -33,6 +33,16 @@ struct StreamDetails {
     uint256 swapAmountRemaining;
 }
 
+struct RemoveLiquidityStream{
+    address user;
+    uint256 lpAmount;
+    uint256 streamCountTotal;
+    uint256 streamCountRemaining;
+    uint256 conversionPerStream;
+    uint256 tokenAmountOut;
+    uint256 conversionRemaining;
+}
+
 enum TYPE_OF_LP {
     SINGLE_TOKEN,
     DUAL_TOKEN

--- a/test/concrete/router/RouterRemoveLiq.t.sol
+++ b/test/concrete/router/RouterRemoveLiq.t.sol
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Deploys} from "test/shared/DeploysForRouter.t.sol";
+import {IRouterErrors} from "src/interfaces/router/IRouterErrors.sol";
+import {LiquidityStream,RemoveLiquidityStream} from "src/lib/SwapQueue.sol";
+import "forge-std/Test.sol";
+
+
+contract RouterTest is Deploys {
+    address nonAuthorized = makeAddr("nonAuthorized");
+
+    function setUp() public virtual override {
+        super.setUp();
+    }
+
+    // ======================================= PERMISSIONLESS POOLS ========================================//
+    function _initGenesisPool(uint256 d, uint256 a) internal {
+        vm.startPrank(owner);
+        tokenA.approve(address(router), a);
+        router.initGenesisPool(address(tokenA), a, d);
+        vm.stopPrank();
+    }
+
+    function test_removeLiqFromGenesisPoolSingleStream_success() public {
+
+        uint256 tokenAReserve = 100e18;
+        uint256 dToMint = 10e18;
+        _initGenesisPool(dToMint, tokenAReserve);
+
+        vm.startPrank(owner);
+
+        (
+            uint256 reserveD,
+            uint256 poolOwnershipUnitsTotal,
+            uint256 reserveA,
+            uint256 initialDToMint,
+            uint256 poolFeeCollected,
+            bool initialized
+        ) = pool.poolInfo(address(tokenA));
+
+        
+        uint userLpUnits = pool.userLpUnitInfo(owner,address(tokenA));
+
+        uint256 expectedStreamCount = poolLogic.calculateStreamCount(userLpUnits, pool.globalSlippage(), reserveD);
+        uint expectedConversionPerStream = userLpUnits / expectedStreamCount;
+        uint expectedTokenAmountOutPerStream = poolLogic.calculateAssetTransfer(expectedConversionPerStream, reserveA, poolOwnershipUnitsTotal);
+        uint userTokenBalanceBefore = tokenA.balanceOf(owner);
+        router.removeLiquidity(address(tokenA), userLpUnits);
+
+        (RemoveLiquidityStream[] memory removeLiqStreams, uint front, uint back) = pool.removeLiquidityStreamQueue(address(tokenA));
+        RemoveLiquidityStream memory removeLiqStream = removeLiqStreams[front];
+        
+        
+        assertEq(front,back-1); // as stream is not being consumed yet
+        assertEq(removeLiqStream.lpAmount,userLpUnits);
+        assertEq(removeLiqStream.user,owner);
+        assertEq(removeLiqStream.tokenAmountOut,expectedTokenAmountOutPerStream);
+        assertEq(removeLiqStream.conversionRemaining,userLpUnits-expectedConversionPerStream);
+        assertEq(removeLiqStream.streamCountTotal,expectedStreamCount);
+        assertEq(removeLiqStream.streamCountRemaining,expectedStreamCount-1);
+        assertEq(removeLiqStream.conversionPerStream,expectedConversionPerStream);
+        assertEq(pool.userLpUnitInfo(owner,address(tokenA)),0);
+
+        // checking reserves after
+
+        (
+            uint256 reserveDA_After,
+            uint256 poolOwnershipUnitsTotal_After,
+            uint256 reserveA_After,
+            uint256 initialDToMint_After,
+            uint256 poolFeeCollected_After,
+            bool initialized_After
+        ) = pool.poolInfo(address(tokenA));
+
+        assertEq(reserveDA_After,reserveD);
+        assertEq(poolOwnershipUnitsTotal_After,poolOwnershipUnitsTotal - expectedConversionPerStream);
+        assertEq(reserveA_After,reserveA - expectedTokenAmountOutPerStream);
+        assertEq(initialDToMint_After,initialDToMint);
+        assertEq(poolFeeCollected_After,poolFeeCollected);
+        assertEq(initialized_After,initialized);
+
+        // checking user should not receive tokens
+        assertEq(tokenA.balanceOf(owner),userTokenBalanceBefore);
+
+
+    }
+
+    function test_removeLiqFromGenesisPoolCompleteStream_success() public {
+
+        uint256 tokenAReserve = 100e18;
+        uint256 dToMint = 10e18;
+        _initGenesisPool(dToMint, tokenAReserve);
+
+        vm.startPrank(owner);
+
+        (
+            uint256 reserveD,
+            uint256 poolOwnershipUnitsTotal,
+            uint256 reserveA,
+            uint256 initialDToMint,
+            uint256 poolFeeCollected,
+            bool initialized
+        ) = pool.poolInfo(address(tokenA));
+
+        
+        uint userLpUnits = pool.userLpUnitInfo(owner,address(tokenA));
+
+        uint256 expectedStreamCount = poolLogic.calculateStreamCount(userLpUnits, pool.globalSlippage(), reserveD);
+        uint expectedConversionPerStream = userLpUnits / expectedStreamCount;
+        uint expectedTokenAmountOutPerStream = poolLogic.calculateAssetTransfer(expectedConversionPerStream, reserveA, poolOwnershipUnitsTotal);
+        (RemoveLiquidityStream[] memory removeLiqStreams, uint front, uint back) = pool.removeLiquidityStreamQueue(address(tokenA));
+        uint userTokenBalanceBefore = tokenA.balanceOf(owner);
+        router.removeLiquidity(address(tokenA), userLpUnits);
+
+        assertEq(pool.userLpUnitInfo(owner,address(tokenA)),0);
+
+        for(uint i; i < expectedStreamCount; i++) {
+            router.processRemoveLiquidity(address(tokenA));
+        }
+
+        (RemoveLiquidityStream[] memory removeLiqStreams_After, uint front_After, uint back_After) = pool.removeLiquidityStreamQueue(address(tokenA));
+        RemoveLiquidityStream memory removeLiqStream = removeLiqStreams_After[front_After - 1];
+        
+        
+        assertEq(front,back); // as stream is consumed
+        assertEq(removeLiqStream.lpAmount,userLpUnits);
+        assertEq(removeLiqStream.user,owner);
+        assertEq(removeLiqStream.tokenAmountOut,expectedTokenAmountOutPerStream * expectedStreamCount);
+        assertEq(removeLiqStream.conversionRemaining,0);
+        assertEq(removeLiqStream.streamCountTotal,expectedStreamCount);
+        assertEq(removeLiqStream.streamCountRemaining,0);
+        assertEq(removeLiqStream.conversionPerStream,expectedConversionPerStream);
+        assertEq(pool.userLpUnitInfo(owner,address(tokenA)),0);
+        
+
+        // checking reserves after
+
+        (
+            uint256 reserveDA_After,
+            uint256 poolOwnershipUnitsTotal_After,
+            uint256 reserveA_After,
+            uint256 initialDToMint_After,
+            uint256 poolFeeCollected_After,
+            bool initialized_After
+        ) = pool.poolInfo(address(tokenA));
+
+        assertEq(reserveDA_After,reserveD);
+        assertEq(poolOwnershipUnitsTotal_After,poolOwnershipUnitsTotal - (expectedConversionPerStream * expectedStreamCount));
+        assertEq(reserveA_After,reserveA - (expectedTokenAmountOutPerStream * expectedStreamCount));
+        assertEq(initialDToMint_After,initialDToMint);
+        assertEq(poolFeeCollected_After,poolFeeCollected);
+        assertEq(initialized_After,initialized);
+
+        // checking if user received tokens
+        assertEq(tokenA.balanceOf(owner),userTokenBalanceBefore + removeLiqStream.tokenAmountOut);
+    }
+
+    function test_removeLiqFromPermissionlesspoolSingleStream_success() public {
+
+        uint256 tokenAReserve = 100e18;
+        uint256 dToMint = 10e18;
+        _initGenesisPool(dToMint, tokenAReserve);
+
+        vm.startPrank(owner);
+        uint256 tokenAmount = 100e18;
+        uint256 dToTokenAmount = 50e18;
+
+        tokenB.approve(address(router), tokenAmount);
+        tokenA.approve(address(router), dToTokenAmount);
+        
+        router.initPool(address(tokenB), address(tokenA), tokenAmount, dToTokenAmount);
+
+        bytes32 pairId = keccak256(abi.encodePacked(address(tokenB), address(tokenA)));
+        (LiquidityStream[] memory streams, uint256 front, uint256 back) = pool.liquidityStreamQueue(pairId);
+
+        for(uint8 i = 0; i<streams[front].poolBStream.streamsRemaining; i++){
+            router.processLiqStream(address(tokenB), address(tokenA));
+        }
+
+        (
+            uint256 reserveD,
+            uint256 poolOwnershipUnitsTotal,
+            uint256 reserveA,
+            uint256 initialDToMint,
+            uint256 poolFeeCollected,
+            bool initialized
+        ) = pool.poolInfo(address(tokenB));
+
+        uint userLpUnits_poolB = pool.userLpUnitInfo(owner,address(tokenB));
+        uint userTokenBalanceBefore = tokenB.balanceOf(owner);
+        uint256 expectedStreamCount = poolLogic.calculateStreamCount(userLpUnits_poolB, pool.globalSlippage(), reserveD);
+        uint expectedConversionPerStream = userLpUnits_poolB / expectedStreamCount;
+        uint expectedTokenAmountOutPerStream = poolLogic.calculateAssetTransfer(expectedConversionPerStream, reserveA, poolOwnershipUnitsTotal);
+        uint dust = userLpUnits_poolB % expectedStreamCount; 
+        if(dust != 0 ) {
+            userLpUnits_poolB = expectedConversionPerStream * expectedStreamCount;
+        }
+        router.removeLiquidity(address(tokenB), userLpUnits_poolB);
+
+        (RemoveLiquidityStream[] memory removeLiqStreams, uint removeLiqStreamfront, uint removeLiqStreamback) = pool.removeLiquidityStreamQueue(address(tokenB));
+        RemoveLiquidityStream memory removeLiqStream = removeLiqStreams[removeLiqStreamfront];
+        
+        
+        assertEq(removeLiqStreamfront,removeLiqStreamback-1); // as stream is not being consumed yet
+        assertEq(removeLiqStream.lpAmount,userLpUnits_poolB);
+        assertEq(removeLiqStream.user,owner);
+        assertEq(removeLiqStream.tokenAmountOut,expectedTokenAmountOutPerStream);
+        assertEq(removeLiqStream.conversionRemaining,userLpUnits_poolB-expectedConversionPerStream);
+        assertEq(removeLiqStream.streamCountTotal,expectedStreamCount);
+        assertEq(removeLiqStream.streamCountRemaining,expectedStreamCount-1);
+        assertEq(removeLiqStream.conversionPerStream,expectedConversionPerStream);
+        assertEq(pool.userLpUnitInfo(owner,address(tokenB)),dust);
+
+        // checking reserves after
+
+        (
+            uint256 reserveDA_After,
+            uint256 poolOwnershipUnitsTotal_After,
+            uint256 reserveA_After,
+            uint256 initialDToMint_After,
+            uint256 poolFeeCollected_After,
+            bool initialized_After
+        ) = pool.poolInfo(address(tokenB));
+
+        assertEq(reserveDA_After,reserveD);
+        assertEq(poolOwnershipUnitsTotal_After,poolOwnershipUnitsTotal - expectedConversionPerStream);
+        assertEq(reserveA_After,reserveA - expectedTokenAmountOutPerStream);
+        assertEq(initialDToMint_After,initialDToMint);
+        assertEq(poolFeeCollected_After,poolFeeCollected);
+        assertEq(initialized_After,initialized);
+
+        // checking user should not receive tokens
+        assertEq(tokenB.balanceOf(owner),userTokenBalanceBefore);
+
+    }
+
+    function test_removeLiqFromPermissionlesspoolCompleteStream_success() public {
+
+        uint256 tokenAReserve = 100e18;
+        uint256 dToMint = 10e18;
+        _initGenesisPool(dToMint, tokenAReserve);
+
+        vm.startPrank(owner);
+        uint256 tokenAmount = 100e18;
+        uint256 dToTokenAmount = 50e18;
+
+        tokenB.approve(address(router), tokenAmount);
+        tokenA.approve(address(router), dToTokenAmount);
+        
+        router.initPool(address(tokenB), address(tokenA), tokenAmount, dToTokenAmount);
+
+        bytes32 pairId = keccak256(abi.encodePacked(address(tokenB), address(tokenA)));
+        (LiquidityStream[] memory streams, uint256 front, uint256 back) = pool.liquidityStreamQueue(pairId);
+
+        for(uint8 i = 0; i<streams[front].poolBStream.streamsRemaining; i++){
+            router.processLiqStream(address(tokenB), address(tokenA));
+        }
+
+        (
+            uint256 reserveD,
+            uint256 poolOwnershipUnitsTotal,
+            uint256 reserveA,
+            uint256 initialDToMint,
+            uint256 poolFeeCollected,
+            bool initialized
+        ) = pool.poolInfo(address(tokenB));
+
+        uint userLpUnits_poolB = pool.userLpUnitInfo(owner,address(tokenB));
+        uint userTokenBalanceBefore = tokenB.balanceOf(owner);
+        uint256 expectedStreamCount = poolLogic.calculateStreamCount(userLpUnits_poolB, pool.globalSlippage(), reserveD);
+        uint expectedConversionPerStream = userLpUnits_poolB / expectedStreamCount;
+        uint dust = userLpUnits_poolB % expectedStreamCount; 
+        if(dust != 0 ) {
+            userLpUnits_poolB = expectedConversionPerStream * expectedStreamCount;
+        }
+        router.removeLiquidity(address(tokenB), userLpUnits_poolB);
+        assertEq(pool.userLpUnitInfo(owner,address(tokenB)),dust);
+
+        uint expectedTokenAmountAfterStreamExec;
+        uint poolOwnershipUnitsTotalCached = poolOwnershipUnitsTotal;
+        uint reservesACached = reserveA;
+        for(uint i; i < expectedStreamCount; i++) {
+            router.processRemoveLiquidity(address(tokenB));
+            uint expectedAmountOut = poolLogic.calculateAssetTransfer(expectedConversionPerStream, reservesACached, poolOwnershipUnitsTotalCached);
+            expectedTokenAmountAfterStreamExec += expectedAmountOut; 
+            poolOwnershipUnitsTotalCached -= expectedConversionPerStream;
+            reservesACached -= expectedAmountOut;
+        }
+
+        (RemoveLiquidityStream[] memory removeLiqStreams, uint removeLiqStreamfront, uint removeLiqStreamback) = pool.removeLiquidityStreamQueue(address(tokenB));
+        RemoveLiquidityStream memory removeLiqStream = removeLiqStreams[removeLiqStreamfront - 1];
+        
+        
+        assertEq(removeLiqStreamfront,removeLiqStreamback); // as stream is consumed
+        assertEq(removeLiqStream.lpAmount,userLpUnits_poolB);
+        assertEq(removeLiqStream.user,owner);
+        assertEq(removeLiqStream.tokenAmountOut,expectedTokenAmountAfterStreamExec);
+        assertEq(removeLiqStream.conversionRemaining,0);
+        assertEq(removeLiqStream.streamCountTotal,expectedStreamCount);
+        assertEq(removeLiqStream.streamCountRemaining,0);
+        assertEq(removeLiqStream.conversionPerStream,expectedConversionPerStream);
+        assertEq(pool.userLpUnitInfo(owner,address(tokenB)),dust);
+
+        // checking reserves after
+{
+        (
+            uint256 reserveDA_After,
+            uint256 poolOwnershipUnitsTotal_After,
+            uint256 reserveA_After,
+            uint256 initialDToMint_After,
+            uint256 poolFeeCollected_After,
+            bool initialized_After
+        ) = pool.poolInfo(address(tokenB));
+
+        assertEq(reserveDA_After,reserveD);
+        assertEq(poolOwnershipUnitsTotal_After,poolOwnershipUnitsTotalCached);
+        assertEq(reserveA_After,reservesACached);
+        assertEq(initialDToMint_After,initialDToMint);
+        assertEq(poolFeeCollected_After,poolFeeCollected);
+        assertEq(initialized_After,initialized);
+    }
+
+        // checking user should receive tokens as the stream is completed
+        assertEq(tokenB.balanceOf(owner),userTokenBalanceBefore +  expectedTokenAmountAfterStreamExec);
+
+    }
+
+    function test_removeLiquidity_invalidPool() public {
+        vm.expectRevert(IRouterErrors.InvalidPool.selector);
+        router.removeLiquidity(address(tokenA), 1);
+    }
+    
+    function test_removeLiquidity_invalidAmount() public {
+        uint256 tokenAReserve = 100e18;
+        uint256 dToMint = 10e18;
+        _initGenesisPool(dToMint, tokenAReserve);
+        vm.startPrank(owner);
+        // when 0 value
+        vm.expectRevert(IRouterErrors.InvalidAmount.selector);
+        router.removeLiquidity(address(tokenA), 0);
+
+        // passing value more than user's lp balance
+        uint userLpUnits = pool.userLpUnitInfo(owner, address(tokenA));
+        vm.expectRevert(IRouterErrors.InvalidAmount.selector);
+        router.removeLiquidity(address(tokenA), userLpUnits + 1); // +1 to make balance more than what user has
+
+        // calling with a user who has no lp units
+        address randomUser = address(0x1234);
+        vm.startPrank(randomUser);
+        vm.expectRevert(IRouterErrors.InvalidAmount.selector);
+        router.removeLiquidity(address(tokenA), 1);
+
+    }
+    
+
+
+}

--- a/test/concrete/router/RouterRemoveLiq.t.sol
+++ b/test/concrete/router/RouterRemoveLiq.t.sol
@@ -3,9 +3,8 @@ pragma solidity ^0.8.13;
 
 import {Deploys} from "test/shared/DeploysForRouter.t.sol";
 import {IRouterErrors} from "src/interfaces/router/IRouterErrors.sol";
-import {LiquidityStream,RemoveLiquidityStream} from "src/lib/SwapQueue.sol";
+import {LiquidityStream, RemoveLiquidityStream} from "src/lib/SwapQueue.sol";
 import "forge-std/Test.sol";
-
 
 contract RouterTest is Deploys {
     address nonAuthorized = makeAddr("nonAuthorized");
@@ -23,7 +22,6 @@ contract RouterTest is Deploys {
     }
 
     function test_removeLiqFromGenesisPoolSingleStream_success() public {
-
         uint256 tokenAReserve = 100e18;
         uint256 dToMint = 10e18;
         _initGenesisPool(dToMint, tokenAReserve);
@@ -39,28 +37,28 @@ contract RouterTest is Deploys {
             bool initialized
         ) = pool.poolInfo(address(tokenA));
 
-        
-        uint userLpUnits = pool.userLpUnitInfo(owner,address(tokenA));
+        uint256 userLpUnits = pool.userLpUnitInfo(owner, address(tokenA));
 
         uint256 expectedStreamCount = poolLogic.calculateStreamCount(userLpUnits, pool.globalSlippage(), reserveD);
-        uint expectedConversionPerStream = userLpUnits / expectedStreamCount;
-        uint expectedTokenAmountOutPerStream = poolLogic.calculateAssetTransfer(expectedConversionPerStream, reserveA, poolOwnershipUnitsTotal);
-        uint userTokenBalanceBefore = tokenA.balanceOf(owner);
+        uint256 expectedConversionPerStream = userLpUnits / expectedStreamCount;
+        uint256 expectedTokenAmountOutPerStream =
+            poolLogic.calculateAssetTransfer(expectedConversionPerStream, reserveA, poolOwnershipUnitsTotal);
+        uint256 userTokenBalanceBefore = tokenA.balanceOf(owner);
         router.removeLiquidity(address(tokenA), userLpUnits);
 
-        (RemoveLiquidityStream[] memory removeLiqStreams, uint front, uint back) = pool.removeLiquidityStreamQueue(address(tokenA));
+        (RemoveLiquidityStream[] memory removeLiqStreams, uint256 front, uint256 back) =
+            pool.removeLiquidityStreamQueue(address(tokenA));
         RemoveLiquidityStream memory removeLiqStream = removeLiqStreams[front];
-        
-        
-        assertEq(front,back-1); // as stream is not being consumed yet
-        assertEq(removeLiqStream.lpAmount,userLpUnits);
-        assertEq(removeLiqStream.user,owner);
-        assertEq(removeLiqStream.tokenAmountOut,expectedTokenAmountOutPerStream);
-        assertEq(removeLiqStream.conversionRemaining,userLpUnits-expectedConversionPerStream);
-        assertEq(removeLiqStream.streamCountTotal,expectedStreamCount);
-        assertEq(removeLiqStream.streamCountRemaining,expectedStreamCount-1);
-        assertEq(removeLiqStream.conversionPerStream,expectedConversionPerStream);
-        assertEq(pool.userLpUnitInfo(owner,address(tokenA)),0);
+
+        assertEq(front, back - 1); // as stream is not being consumed yet
+        assertEq(removeLiqStream.lpAmount, userLpUnits);
+        assertEq(removeLiqStream.user, owner);
+        assertEq(removeLiqStream.tokenAmountOut, expectedTokenAmountOutPerStream);
+        assertEq(removeLiqStream.conversionRemaining, userLpUnits - expectedConversionPerStream);
+        assertEq(removeLiqStream.streamCountTotal, expectedStreamCount);
+        assertEq(removeLiqStream.streamCountRemaining, expectedStreamCount - 1);
+        assertEq(removeLiqStream.conversionPerStream, expectedConversionPerStream);
+        assertEq(pool.userLpUnitInfo(owner, address(tokenA)), 0);
 
         // checking reserves after
 
@@ -73,21 +71,18 @@ contract RouterTest is Deploys {
             bool initialized_After
         ) = pool.poolInfo(address(tokenA));
 
-        assertEq(reserveDA_After,reserveD);
-        assertEq(poolOwnershipUnitsTotal_After,poolOwnershipUnitsTotal - expectedConversionPerStream);
-        assertEq(reserveA_After,reserveA - expectedTokenAmountOutPerStream);
-        assertEq(initialDToMint_After,initialDToMint);
-        assertEq(poolFeeCollected_After,poolFeeCollected);
-        assertEq(initialized_After,initialized);
+        assertEq(reserveDA_After, reserveD);
+        assertEq(poolOwnershipUnitsTotal_After, poolOwnershipUnitsTotal - expectedConversionPerStream);
+        assertEq(reserveA_After, reserveA - expectedTokenAmountOutPerStream);
+        assertEq(initialDToMint_After, initialDToMint);
+        assertEq(poolFeeCollected_After, poolFeeCollected);
+        assertEq(initialized_After, initialized);
 
         // checking user should not receive tokens
-        assertEq(tokenA.balanceOf(owner),userTokenBalanceBefore);
-
-
+        assertEq(tokenA.balanceOf(owner), userTokenBalanceBefore);
     }
 
     function test_removeLiqFromGenesisPoolCompleteStream_success() public {
-
         uint256 tokenAReserve = 100e18;
         uint256 dToMint = 10e18;
         _initGenesisPool(dToMint, tokenAReserve);
@@ -103,36 +98,36 @@ contract RouterTest is Deploys {
             bool initialized
         ) = pool.poolInfo(address(tokenA));
 
-        
-        uint userLpUnits = pool.userLpUnitInfo(owner,address(tokenA));
+        uint256 userLpUnits = pool.userLpUnitInfo(owner, address(tokenA));
 
         uint256 expectedStreamCount = poolLogic.calculateStreamCount(userLpUnits, pool.globalSlippage(), reserveD);
-        uint expectedConversionPerStream = userLpUnits / expectedStreamCount;
-        uint expectedTokenAmountOutPerStream = poolLogic.calculateAssetTransfer(expectedConversionPerStream, reserveA, poolOwnershipUnitsTotal);
-        (RemoveLiquidityStream[] memory removeLiqStreams, uint front, uint back) = pool.removeLiquidityStreamQueue(address(tokenA));
-        uint userTokenBalanceBefore = tokenA.balanceOf(owner);
+        uint256 expectedConversionPerStream = userLpUnits / expectedStreamCount;
+        uint256 expectedTokenAmountOutPerStream =
+            poolLogic.calculateAssetTransfer(expectedConversionPerStream, reserveA, poolOwnershipUnitsTotal);
+        (RemoveLiquidityStream[] memory removeLiqStreams, uint256 front, uint256 back) =
+            pool.removeLiquidityStreamQueue(address(tokenA));
+        uint256 userTokenBalanceBefore = tokenA.balanceOf(owner);
         router.removeLiquidity(address(tokenA), userLpUnits);
 
-        assertEq(pool.userLpUnitInfo(owner,address(tokenA)),0);
+        assertEq(pool.userLpUnitInfo(owner, address(tokenA)), 0);
 
-        for(uint i; i < expectedStreamCount; i++) {
+        for (uint256 i; i < expectedStreamCount; i++) {
             router.processRemoveLiquidity(address(tokenA));
         }
 
-        (RemoveLiquidityStream[] memory removeLiqStreams_After, uint front_After, uint back_After) = pool.removeLiquidityStreamQueue(address(tokenA));
+        (RemoveLiquidityStream[] memory removeLiqStreams_After, uint256 front_After, uint256 back_After) =
+            pool.removeLiquidityStreamQueue(address(tokenA));
         RemoveLiquidityStream memory removeLiqStream = removeLiqStreams_After[front_After - 1];
-        
-        
-        assertEq(front,back); // as stream is consumed
-        assertEq(removeLiqStream.lpAmount,userLpUnits);
-        assertEq(removeLiqStream.user,owner);
-        assertEq(removeLiqStream.tokenAmountOut,expectedTokenAmountOutPerStream * expectedStreamCount);
-        assertEq(removeLiqStream.conversionRemaining,0);
-        assertEq(removeLiqStream.streamCountTotal,expectedStreamCount);
-        assertEq(removeLiqStream.streamCountRemaining,0);
-        assertEq(removeLiqStream.conversionPerStream,expectedConversionPerStream);
-        assertEq(pool.userLpUnitInfo(owner,address(tokenA)),0);
-        
+
+        assertEq(front, back); // as stream is consumed
+        assertEq(removeLiqStream.lpAmount, userLpUnits);
+        assertEq(removeLiqStream.user, owner);
+        assertEq(removeLiqStream.tokenAmountOut, expectedTokenAmountOutPerStream * expectedStreamCount);
+        assertEq(removeLiqStream.conversionRemaining, 0);
+        assertEq(removeLiqStream.streamCountTotal, expectedStreamCount);
+        assertEq(removeLiqStream.streamCountRemaining, 0);
+        assertEq(removeLiqStream.conversionPerStream, expectedConversionPerStream);
+        assertEq(pool.userLpUnitInfo(owner, address(tokenA)), 0);
 
         // checking reserves after
 
@@ -145,19 +140,20 @@ contract RouterTest is Deploys {
             bool initialized_After
         ) = pool.poolInfo(address(tokenA));
 
-        assertEq(reserveDA_After,reserveD);
-        assertEq(poolOwnershipUnitsTotal_After,poolOwnershipUnitsTotal - (expectedConversionPerStream * expectedStreamCount));
-        assertEq(reserveA_After,reserveA - (expectedTokenAmountOutPerStream * expectedStreamCount));
-        assertEq(initialDToMint_After,initialDToMint);
-        assertEq(poolFeeCollected_After,poolFeeCollected);
-        assertEq(initialized_After,initialized);
+        assertEq(reserveDA_After, reserveD);
+        assertEq(
+            poolOwnershipUnitsTotal_After, poolOwnershipUnitsTotal - (expectedConversionPerStream * expectedStreamCount)
+        );
+        assertEq(reserveA_After, reserveA - (expectedTokenAmountOutPerStream * expectedStreamCount));
+        assertEq(initialDToMint_After, initialDToMint);
+        assertEq(poolFeeCollected_After, poolFeeCollected);
+        assertEq(initialized_After, initialized);
 
         // checking if user received tokens
-        assertEq(tokenA.balanceOf(owner),userTokenBalanceBefore + removeLiqStream.tokenAmountOut);
+        assertEq(tokenA.balanceOf(owner), userTokenBalanceBefore + removeLiqStream.tokenAmountOut);
     }
 
     function test_removeLiqFromPermissionlesspoolSingleStream_success() public {
-
         uint256 tokenAReserve = 100e18;
         uint256 dToMint = 10e18;
         _initGenesisPool(dToMint, tokenAReserve);
@@ -168,13 +164,13 @@ contract RouterTest is Deploys {
 
         tokenB.approve(address(router), tokenAmount);
         tokenA.approve(address(router), dToTokenAmount);
-        
+
         router.initPool(address(tokenB), address(tokenA), tokenAmount, dToTokenAmount);
 
         bytes32 pairId = keccak256(abi.encodePacked(address(tokenB), address(tokenA)));
         (LiquidityStream[] memory streams, uint256 front, uint256 back) = pool.liquidityStreamQueue(pairId);
 
-        for(uint8 i = 0; i<streams[front].poolBStream.streamsRemaining; i++){
+        for (uint8 i = 0; i < streams[front].poolBStream.streamsRemaining; i++) {
             router.processLiqStream(address(tokenB), address(tokenA));
         }
 
@@ -187,30 +183,31 @@ contract RouterTest is Deploys {
             bool initialized
         ) = pool.poolInfo(address(tokenB));
 
-        uint userLpUnits_poolB = pool.userLpUnitInfo(owner,address(tokenB));
-        uint userTokenBalanceBefore = tokenB.balanceOf(owner);
+        uint256 userLpUnits_poolB = pool.userLpUnitInfo(owner, address(tokenB));
+        uint256 userTokenBalanceBefore = tokenB.balanceOf(owner);
         uint256 expectedStreamCount = poolLogic.calculateStreamCount(userLpUnits_poolB, pool.globalSlippage(), reserveD);
-        uint expectedConversionPerStream = userLpUnits_poolB / expectedStreamCount;
-        uint expectedTokenAmountOutPerStream = poolLogic.calculateAssetTransfer(expectedConversionPerStream, reserveA, poolOwnershipUnitsTotal);
-        uint dust = userLpUnits_poolB % expectedStreamCount; 
-        if(dust != 0 ) {
+        uint256 expectedConversionPerStream = userLpUnits_poolB / expectedStreamCount;
+        uint256 expectedTokenAmountOutPerStream =
+            poolLogic.calculateAssetTransfer(expectedConversionPerStream, reserveA, poolOwnershipUnitsTotal);
+        uint256 dust = userLpUnits_poolB % expectedStreamCount;
+        if (dust != 0) {
             userLpUnits_poolB = expectedConversionPerStream * expectedStreamCount;
         }
         router.removeLiquidity(address(tokenB), userLpUnits_poolB);
 
-        (RemoveLiquidityStream[] memory removeLiqStreams, uint removeLiqStreamfront, uint removeLiqStreamback) = pool.removeLiquidityStreamQueue(address(tokenB));
+        (RemoveLiquidityStream[] memory removeLiqStreams, uint256 removeLiqStreamfront, uint256 removeLiqStreamback) =
+            pool.removeLiquidityStreamQueue(address(tokenB));
         RemoveLiquidityStream memory removeLiqStream = removeLiqStreams[removeLiqStreamfront];
-        
-        
-        assertEq(removeLiqStreamfront,removeLiqStreamback-1); // as stream is not being consumed yet
-        assertEq(removeLiqStream.lpAmount,userLpUnits_poolB);
-        assertEq(removeLiqStream.user,owner);
-        assertEq(removeLiqStream.tokenAmountOut,expectedTokenAmountOutPerStream);
-        assertEq(removeLiqStream.conversionRemaining,userLpUnits_poolB-expectedConversionPerStream);
-        assertEq(removeLiqStream.streamCountTotal,expectedStreamCount);
-        assertEq(removeLiqStream.streamCountRemaining,expectedStreamCount-1);
-        assertEq(removeLiqStream.conversionPerStream,expectedConversionPerStream);
-        assertEq(pool.userLpUnitInfo(owner,address(tokenB)),dust);
+
+        assertEq(removeLiqStreamfront, removeLiqStreamback - 1); // as stream is not being consumed yet
+        assertEq(removeLiqStream.lpAmount, userLpUnits_poolB);
+        assertEq(removeLiqStream.user, owner);
+        assertEq(removeLiqStream.tokenAmountOut, expectedTokenAmountOutPerStream);
+        assertEq(removeLiqStream.conversionRemaining, userLpUnits_poolB - expectedConversionPerStream);
+        assertEq(removeLiqStream.streamCountTotal, expectedStreamCount);
+        assertEq(removeLiqStream.streamCountRemaining, expectedStreamCount - 1);
+        assertEq(removeLiqStream.conversionPerStream, expectedConversionPerStream);
+        assertEq(pool.userLpUnitInfo(owner, address(tokenB)), dust);
 
         // checking reserves after
 
@@ -223,20 +220,18 @@ contract RouterTest is Deploys {
             bool initialized_After
         ) = pool.poolInfo(address(tokenB));
 
-        assertEq(reserveDA_After,reserveD);
-        assertEq(poolOwnershipUnitsTotal_After,poolOwnershipUnitsTotal - expectedConversionPerStream);
-        assertEq(reserveA_After,reserveA - expectedTokenAmountOutPerStream);
-        assertEq(initialDToMint_After,initialDToMint);
-        assertEq(poolFeeCollected_After,poolFeeCollected);
-        assertEq(initialized_After,initialized);
+        assertEq(reserveDA_After, reserveD);
+        assertEq(poolOwnershipUnitsTotal_After, poolOwnershipUnitsTotal - expectedConversionPerStream);
+        assertEq(reserveA_After, reserveA - expectedTokenAmountOutPerStream);
+        assertEq(initialDToMint_After, initialDToMint);
+        assertEq(poolFeeCollected_After, poolFeeCollected);
+        assertEq(initialized_After, initialized);
 
         // checking user should not receive tokens
-        assertEq(tokenB.balanceOf(owner),userTokenBalanceBefore);
-
+        assertEq(tokenB.balanceOf(owner), userTokenBalanceBefore);
     }
 
     function test_removeLiqFromPermissionlesspoolCompleteStream_success() public {
-
         uint256 tokenAReserve = 100e18;
         uint256 dToMint = 10e18;
         _initGenesisPool(dToMint, tokenAReserve);
@@ -247,13 +242,13 @@ contract RouterTest is Deploys {
 
         tokenB.approve(address(router), tokenAmount);
         tokenA.approve(address(router), dToTokenAmount);
-        
+
         router.initPool(address(tokenB), address(tokenA), tokenAmount, dToTokenAmount);
 
         bytes32 pairId = keccak256(abi.encodePacked(address(tokenB), address(tokenA)));
         (LiquidityStream[] memory streams, uint256 front, uint256 back) = pool.liquidityStreamQueue(pairId);
 
-        for(uint8 i = 0; i<streams[front].poolBStream.streamsRemaining; i++){
+        for (uint8 i = 0; i < streams[front].poolBStream.streamsRemaining; i++) {
             router.processLiqStream(address(tokenB), address(tokenA));
         }
 
@@ -266,71 +261,72 @@ contract RouterTest is Deploys {
             bool initialized
         ) = pool.poolInfo(address(tokenB));
 
-        uint userLpUnits_poolB = pool.userLpUnitInfo(owner,address(tokenB));
-        uint userTokenBalanceBefore = tokenB.balanceOf(owner);
+        uint256 userLpUnits_poolB = pool.userLpUnitInfo(owner, address(tokenB));
+        uint256 userTokenBalanceBefore = tokenB.balanceOf(owner);
         uint256 expectedStreamCount = poolLogic.calculateStreamCount(userLpUnits_poolB, pool.globalSlippage(), reserveD);
-        uint expectedConversionPerStream = userLpUnits_poolB / expectedStreamCount;
-        uint dust = userLpUnits_poolB % expectedStreamCount; 
-        if(dust != 0 ) {
+        uint256 expectedConversionPerStream = userLpUnits_poolB / expectedStreamCount;
+        uint256 dust = userLpUnits_poolB % expectedStreamCount;
+        if (dust != 0) {
             userLpUnits_poolB = expectedConversionPerStream * expectedStreamCount;
         }
         router.removeLiquidity(address(tokenB), userLpUnits_poolB);
-        assertEq(pool.userLpUnitInfo(owner,address(tokenB)),dust);
+        assertEq(pool.userLpUnitInfo(owner, address(tokenB)), dust);
 
-        uint expectedTokenAmountAfterStreamExec;
-        uint poolOwnershipUnitsTotalCached = poolOwnershipUnitsTotal;
-        uint reservesACached = reserveA;
-        for(uint i; i < expectedStreamCount; i++) {
+        uint256 expectedTokenAmountAfterStreamExec;
+        uint256 poolOwnershipUnitsTotalCached = poolOwnershipUnitsTotal;
+        uint256 reservesACached = reserveA;
+        for (uint256 i; i < expectedStreamCount; i++) {
             router.processRemoveLiquidity(address(tokenB));
-            uint expectedAmountOut = poolLogic.calculateAssetTransfer(expectedConversionPerStream, reservesACached, poolOwnershipUnitsTotalCached);
-            expectedTokenAmountAfterStreamExec += expectedAmountOut; 
+            uint256 expectedAmountOut = poolLogic.calculateAssetTransfer(
+                expectedConversionPerStream, reservesACached, poolOwnershipUnitsTotalCached
+            );
+            expectedTokenAmountAfterStreamExec += expectedAmountOut;
             poolOwnershipUnitsTotalCached -= expectedConversionPerStream;
             reservesACached -= expectedAmountOut;
         }
 
-        (RemoveLiquidityStream[] memory removeLiqStreams, uint removeLiqStreamfront, uint removeLiqStreamback) = pool.removeLiquidityStreamQueue(address(tokenB));
+        (RemoveLiquidityStream[] memory removeLiqStreams, uint256 removeLiqStreamfront, uint256 removeLiqStreamback) =
+            pool.removeLiquidityStreamQueue(address(tokenB));
         RemoveLiquidityStream memory removeLiqStream = removeLiqStreams[removeLiqStreamfront - 1];
-        
-        
-        assertEq(removeLiqStreamfront,removeLiqStreamback); // as stream is consumed
-        assertEq(removeLiqStream.lpAmount,userLpUnits_poolB);
-        assertEq(removeLiqStream.user,owner);
-        assertEq(removeLiqStream.tokenAmountOut,expectedTokenAmountAfterStreamExec);
-        assertEq(removeLiqStream.conversionRemaining,0);
-        assertEq(removeLiqStream.streamCountTotal,expectedStreamCount);
-        assertEq(removeLiqStream.streamCountRemaining,0);
-        assertEq(removeLiqStream.conversionPerStream,expectedConversionPerStream);
-        assertEq(pool.userLpUnitInfo(owner,address(tokenB)),dust);
+
+        assertEq(removeLiqStreamfront, removeLiqStreamback); // as stream is consumed
+        assertEq(removeLiqStream.lpAmount, userLpUnits_poolB);
+        assertEq(removeLiqStream.user, owner);
+        assertEq(removeLiqStream.tokenAmountOut, expectedTokenAmountAfterStreamExec);
+        assertEq(removeLiqStream.conversionRemaining, 0);
+        assertEq(removeLiqStream.streamCountTotal, expectedStreamCount);
+        assertEq(removeLiqStream.streamCountRemaining, 0);
+        assertEq(removeLiqStream.conversionPerStream, expectedConversionPerStream);
+        assertEq(pool.userLpUnitInfo(owner, address(tokenB)), dust);
 
         // checking reserves after
-{
-        (
-            uint256 reserveDA_After,
-            uint256 poolOwnershipUnitsTotal_After,
-            uint256 reserveA_After,
-            uint256 initialDToMint_After,
-            uint256 poolFeeCollected_After,
-            bool initialized_After
-        ) = pool.poolInfo(address(tokenB));
+        {
+            (
+                uint256 reserveDA_After,
+                uint256 poolOwnershipUnitsTotal_After,
+                uint256 reserveA_After,
+                uint256 initialDToMint_After,
+                uint256 poolFeeCollected_After,
+                bool initialized_After
+            ) = pool.poolInfo(address(tokenB));
 
-        assertEq(reserveDA_After,reserveD);
-        assertEq(poolOwnershipUnitsTotal_After,poolOwnershipUnitsTotalCached);
-        assertEq(reserveA_After,reservesACached);
-        assertEq(initialDToMint_After,initialDToMint);
-        assertEq(poolFeeCollected_After,poolFeeCollected);
-        assertEq(initialized_After,initialized);
-    }
+            assertEq(reserveDA_After, reserveD);
+            assertEq(poolOwnershipUnitsTotal_After, poolOwnershipUnitsTotalCached);
+            assertEq(reserveA_After, reservesACached);
+            assertEq(initialDToMint_After, initialDToMint);
+            assertEq(poolFeeCollected_After, poolFeeCollected);
+            assertEq(initialized_After, initialized);
+        }
 
         // checking user should receive tokens as the stream is completed
-        assertEq(tokenB.balanceOf(owner),userTokenBalanceBefore +  expectedTokenAmountAfterStreamExec);
-
+        assertEq(tokenB.balanceOf(owner), userTokenBalanceBefore + expectedTokenAmountAfterStreamExec);
     }
 
     function test_removeLiquidity_invalidPool() public {
         vm.expectRevert(IRouterErrors.InvalidPool.selector);
         router.removeLiquidity(address(tokenA), 1);
     }
-    
+
     function test_removeLiquidity_invalidAmount() public {
         uint256 tokenAReserve = 100e18;
         uint256 dToMint = 10e18;
@@ -341,7 +337,7 @@ contract RouterTest is Deploys {
         router.removeLiquidity(address(tokenA), 0);
 
         // passing value more than user's lp balance
-        uint userLpUnits = pool.userLpUnitInfo(owner, address(tokenA));
+        uint256 userLpUnits = pool.userLpUnitInfo(owner, address(tokenA));
         vm.expectRevert(IRouterErrors.InvalidAmount.selector);
         router.removeLiquidity(address(tokenA), userLpUnits + 1); // +1 to make balance more than what user has
 
@@ -350,9 +346,5 @@ contract RouterTest is Deploys {
         vm.startPrank(randomUser);
         vm.expectRevert(IRouterErrors.InvalidAmount.selector);
         router.removeLiquidity(address(tokenA), 1);
-
     }
-    
-
-
 }


### PR DESCRIPTION
- removeLiquidity() using streams done.
- processRemoveLiquidity() => For Bot(s).
- Tokens are transferred when all the streams of a single request are processed.
- LpUnits are immediately taken out from user's mapping (global poolOwnershipUnitsTotal are not affected) to stop DOS as user then can request multiple times if not done this way.
- Removing liquidity affects reservesA + userLpUnits + poolOwnershipUnitsTotal states.
- Test cases done.