### PR TITLE
1 stream consumption against opposite swaps

### DIFF
--- a/src/Pool.sol
+++ b/src/Pool.sol
@@ -87,7 +87,7 @@ contract Pool is IPool, Ownable {
     mapping(bytes32 => mapping(uint256 => Swap[])) public triggerAndMarketOrderBook;
     mapping(bytes32 => mapping(uint256 => Swap[])) public limitOrderBook;
 
-    mapping(bytes32 => uint256) public override highestPriceMarker;
+    mapping(bytes32 => uint256) public override highestPriceKey;
 
     address[] public poolAddress;
 
@@ -674,8 +674,8 @@ contract Pool is IPool, Ownable {
         return SWAP_IDS++;
     }
 
-    function setHighestPriceMarker(bytes32 pairId, uint256 value) external override onlyPoolLogic {
-        highestPriceMarker[pairId] = value;
+    function setHighestPriceKey(bytes32 pairId, uint256 value) external override onlyPoolLogic {
+        highestPriceKey[pairId] = value;
     }
 
     function orderBook(

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -155,15 +155,6 @@ contract Router is Ownable, ReentrancyGuard, IRouter {
         IPoolLogic(poolStates.POOL_LOGIC()).processRemoveLiquidity(token);
     }
 
-    function swap(address tokenIn, address tokenOut, uint256 amountIn, uint256 executionPrice) external nonReentrant {
-        // if (amountIn == 0) revert InvalidAmount();
-        // if (executionPrice == 0) revert InvalidExecutionPrice();
-        // if (!poolExist(tokenIn) || !poolExist(tokenOut)) revert InvalidPool();
-
-        // IERC20(tokenIn).safeTransferFrom(msg.sender, POOL_ADDRESS, amountIn);
-        // IPoolLogic(poolStates.POOL_LOGIC()).swap(msg.sender, tokenIn, tokenOut, amountIn, executionPrice);
-    }
-
     function swapMarketOrder(address tokenIn, address tokenOut, uint256 amountIn) external nonReentrant {
         if (amountIn == 0) revert InvalidAmount();
         if (!poolExist(tokenIn) || !poolExist(tokenOut)) revert InvalidPool();

--- a/src/interfaces/pool-logic/IPoolLogicActions.sol
+++ b/src/interfaces/pool-logic/IPoolLogicActions.sol
@@ -42,7 +42,6 @@ interface IPoolLogicActions {
     )
         external;
     function withdrawFromGlobalPool(address user, address token, uint256 amount) external;
-    function swap(address user, address tokenIn, address tokenOut, uint256 amountIn, uint256 executionPrice) external;
     function swapLimitOrder(
         address user,
         address tokenIn,

--- a/src/interfaces/pool/IPoolActions.sol
+++ b/src/interfaces/pool/IPoolActions.sol
@@ -76,7 +76,7 @@ interface IPoolActions {
     function getReserveA(address pool) external view returns (uint256);
     function getReserveD(address pool) external view returns (uint256);
 
-    function setHighestPriceMarker(bytes32 pairId, uint256 value) external;
+    function setHighestPriceKey(bytes32 pairId, uint256 value) external;
 
     function getPoolAddresses() external view returns (address[] memory);
 

--- a/src/interfaces/pool/IPoolStates.sol
+++ b/src/interfaces/pool/IPoolStates.sol
@@ -35,6 +35,6 @@ interface IPoolStates {
         returns (RemoveLiquidityStream[] memory removeLiquidityStream);
 
     function globalPoolDBalance(address) external view returns (uint256);
-    function highestPriceMarker(bytes32) external view returns (uint256);
+    function highestPriceKey(bytes32) external view returns (uint256);
     function orderBook(bytes32 pairId, uint256 priceKey, bool isLimitOrder) external view returns (Swap[] memory);
 }

--- a/src/lib/PoolLogicLib.sol
+++ b/src/lib/PoolLogicLib.sol
@@ -176,6 +176,7 @@ library PoolLogicLib {
     }
 
     // @audit is it gas efficient to pass decimals as inputs
+    // @audit ensure decimals are passed in securely on internal calls
     // @audit is a high level check approach for all non-18 tokens a better way to avoid utilising scaling
     // considerations on every stream execution
     function calculateAmountOutFromPrice(

--- a/test/integration/invariants/Handler.t.sol
+++ b/test/integration/invariants/Handler.t.sol
@@ -50,7 +50,7 @@ contract Handler is Test {
         MockERC20 tokenOut = tokenIn == tokenA ? tokenB : tokenA;
         amountIn = bound(amountIn, 1, MAX_DEPOSIT_SIZE);
         uint256 executionPrice = _getCurrentPrice(address(tokenIn), address(tokenOut));
-        uint256 executionpriceDelta = bound(seed, 0, executionPrice / 10);
+        uint256 executionpriceDelta = bound(seed, 1, executionPrice / 10);
         bool addDelta = _getBoolFromSeed(seed);
         executionPrice = addDelta ? executionPrice + executionpriceDelta : executionPrice - executionpriceDelta;
 
@@ -58,7 +58,7 @@ contract Handler is Test {
         tokenIn.mint(msg.sender, amountIn);
         tokenIn.approve(address(router), amountIn);
 
-        router.swap(address(tokenIn), address(tokenOut), amountIn, executionPrice);
+        router.swapLimitOrder(address(tokenIn), address(tokenOut), amountIn, executionPrice);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
During the processing of limit swaps, only one stream is consumed on each swap, either against the opposite swaps or against the pool.

When we swapping against the opposite swaps:
- we calculate the amountOut of the opposite swaps based on their limit price
- we consume multiple price keys with a starting price key at the highest price key (opposite one), we are not trying to find the opposite price anymore.

few function refactoring